### PR TITLE
Remove use strict in ES6

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,4 +1,3 @@
-'use strict';
 import _ from 'lodash';
 import Module from 'module-js';
 


### PR DESCRIPTION
Hello @mkay581,

Thank you for making tooltip-js!
In this PR, I removed the usage of `'use strict'` which is [not necessary in ES6 modules](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code) because they are always in strict mode.